### PR TITLE
Add general workflows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+  env: {
+    commonjs: true,
+    es2021: true,
+  },
+  overrides: [],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {
+    indent: ['error', 2, { SwitchCase: 1 }],
+    'max-len': [
+      'error',
+      {
+        code: 160,
+        ignoreComments: true,
+        ignoreUrls: true,
+        ignoreStrings: true,
+      },
+    ],
+    'one-var': ['error', 'consecutive'],
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -27,14 +28,3 @@ jobs:
 
       - run: npm install
       - run: npm test
-
-  test_windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - run: npm install
-      - run: npm run-script test-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: npm install
+      - run: npm test
+
+  test_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: npm install
+      - run: npm run-script test-windows

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install modules
+        run: npm install
+      - name: Run ESLint
+        run: npm run lint

--- a/grammar.js
+++ b/grammar.js
@@ -1,6 +1,6 @@
-const const_start = /[A-Z]/;
-const ident_start = /[a-z_\u{00a0}-\u{10ffff}]/u;
-const ident_part = /[0-9A-Za-z_\u{00a0}-\u{10ffff}]/u;
+const const_start = /[A-Z]/,
+  ident_start = /[a-z_\u{00a0}-\u{10ffff}]/u,
+  ident_part = /[0-9A-Za-z_\u{00a0}-\u{10ffff}]/u;
 
 module.exports = grammar({
   name: 'crystal',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "bindings/node",
 	"scripts": {
 		"format": "prettier --write ./grammar.js",
-		"lint": "eslint grammar.js"
+		"lint": "eslint grammar.js",
+		"test": "tree-sitter test"
 	},
 	"keywords": [],
 	"author": "Devaune Whittle <https://github.com/devnote-dev>",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "",
 	"main": "bindings/node",
 	"scripts": {
-		"format": "prettier --write ./grammar.js"
+		"format": "prettier --write ./grammar.js",
+		"lint": "eslint grammar.js"
 	},
 	"keywords": [],
 	"author": "Devaune Whittle <https://github.com/devnote-dev>",
@@ -13,6 +14,7 @@
 		"nan": "^2.17.0"
 	},
 	"devDependencies": {
+		"eslint": "^8.48.0",
 		"prettier": "^2.8.8",
 		"tree-sitter-cli": "^0.20.0"
 	},


### PR DESCRIPTION
(Take 2) This PR adds CI and linting workflows (copied from the official tree-sitter repositories), there is no publish workflow as it requires a [crates.io](https://crates.io/) account, and manual publishing is not an issue anyway. Closes #4.