### PR TITLE
Workflow temporary resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,10 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          # - macos-latest
           - windows-latest
 
     steps:


### PR DESCRIPTION
Removes MacOS from the workflows as it fails for unexpected reasons. The `fail-fast` option has also been removed as it's not necessary for CI.