### PR TITLE
Update parser metadata with filed written by tree-sitter v0.24.3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 node_modules/
 
 package-lock.json
+tree-sitter-crystal.wasm

--- a/package.json
+++ b/package.json
@@ -41,15 +41,6 @@
     "tree-sitter-cli": "^0.20.0",
     "prebuildify": "^6.0.0"
   },
-  "tree-sitter": [
-    {
-      "scope": "source.cr",
-      "file-types": [
-        "cr"
-      ],
-      "highlights": []
-    }
-  ],
   "prettier": {
     "arrowParens": "avoid",
     "singleQuote": true,

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,36 @@
+{
+  "grammars": [
+    {
+      "name": "crystal",
+      "camelcase": "Crystal",
+      "scope": "source.cr",
+      "path": ".",
+      "file-types": [
+        "cr"
+      ],
+      "highlights": []
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "",
+    "authors": [
+      {
+        "name": "Devaune Whittle",
+        "email": "https://github.com/devnote-dev"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/crystal-lang-tools/tree-sitter-crystal"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Everytime I generate the parser tree-sitter CLI does these changes on my working copy.

Running tree-sitter CLI v0.24.3 on ArchLinux.

I also added the wasm file to .gitignore, so I can do:

```
tree-sitter generate && tree-sitter build --wasm && tree-sitter playground -q
```

and not get my working copy dirty.