### PR TITLE
Fix percentage of success when testing the parser against stdlib.

### DIFF
--- a/test/real_world/stdlib
+++ b/test/real_world/stdlib
@@ -64,7 +64,7 @@ stdlib_files.each do |stdlib_file|
   printf("%-63s %s %s\n", test.label, success ? PASS : FAIL, elapsed_ms)
 end
 
-printf("%% of success: %.2f%%\n", pass / stdlib_files.size)
+printf("%% of success: %.2f%%\n", 100 * (pass / stdlib_files.size))
 
 if failed != expected_fail
   abort("List of failed tests difer, check stdlib_failed.txt and stdlib_expected_to_fail.txt".colorize.red)


### PR DESCRIPTION
Current number is 1.47%

Situation for https://github.com/keidax/tree-sitter-crystal is 26.33%

I started taking a look on this shard because keidax one doesn't compile to wasm due to some calls to `fprintf` and use of `stderr`, i.e. should be easy to make it wasm friendly.

Not sure how active is the shard of the delay to accept contributions, but for sure we must find the faster path to have a working parser.